### PR TITLE
Fix building on OSX

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -41,7 +41,11 @@ let releaseNotesData =
 
 let release = List.head releaseNotesData
 
+#if MONO
+let apmTool = "apm"
+#else
 let apmTool = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) </> "atom" </> "bin" </> "apm.cmd"
+#endif
 
 // --------------------------------------------------------------------------------------
 // Build the Generator project and run it
@@ -53,7 +57,7 @@ Target "Clean" (fun _ ->
 )
 
 Target "BuildGenerator" (fun () ->
-    [ __SOURCE_DIRECTORY__ @@ "src" @@ "FSharp.Atom.Generator.fsproj" ]
+    [ __SOURCE_DIRECTORY__ @@ "src" @@ "Paket.Atom.Generator.fsproj" ]
     |> MSBuildDebug "" "Rebuild"
     |> Log "AppBuild-Output: "
 )
@@ -62,7 +66,7 @@ Target "RunGenerator" (fun () ->
     
         (TimeSpan.FromMinutes 5.0)
         |> ProcessHelper.ExecProcess (fun p ->
-            p.FileName <- __SOURCE_DIRECTORY__ @@ "src" @@ "bin" @@ "Debug" @@ "FSharp.Atom.Generator.exe" )
+            p.FileName <- __SOURCE_DIRECTORY__ @@ "src" @@ "bin" @@ "Debug" @@ "Paket.Atom.Generator.exe" )
         |> ignore    
 )
 #if MONO

--- a/src/Paket.Atom.Generator.fsproj
+++ b/src/Paket.Atom.Generator.fsproj
@@ -5,8 +5,8 @@
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{D1081029-2369-4DAA-9F33-2353C5C9ED02}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>FSharp.Atom.Generator</RootNamespace>
-    <AssemblyName>FSharp.Atom.Generator</AssemblyName>
+    <RootNamespace>Paket.Atom.Generator</RootNamespace>
+    <AssemblyName>Paket.Atom.Generator</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/main.fs
+++ b/src/main.fs
@@ -11,7 +11,7 @@ let root = __SOURCE_DIRECTORY__
 // Translate the type given as #1 using module name #2
 // and save the result to a file specified in #3
 let atomModules =
-  [ typeof<Paket.Paket>, "AtomFSharpPaket", "paket/lib/paket.js" ]
+  [ typeof<PaketModule.Paket>, "AtomFSharpPaket", "paket/lib/paket.js" ]
 
 // --------------------------------------------------------------------------------------
 // Compile F# type to an atom module

--- a/src/paket.fs
+++ b/src/paket.fs
@@ -1,5 +1,5 @@
 [<ReflectedDefinition>]
-module Paket
+module PaketModule
 
 open System
 open FunScript


### PR DESCRIPTION
- Changed some leftover references to `FSharp.Atom.Generator` from
  atom-fsharp's build.fsx and .fsproj
- Fixed setting `apmTool` in build.fsx when using MONO
- Changed root module name to `PaketModule` because XBuild was
  complaining about about `A namespace and a module named 'Paket'
  both occur in two parts of this assembly`

I haven't had a chance to verify that it builds on Windows yet but I guess it should be okay.
