### PR TITLE
Fix #34

### DIFF
--- a/release/lib/paket.js
+++ b/release/lib/paket.js
@@ -2,6 +2,7 @@ var CompositeDisposable = require('atom').CompositeDisposable;
 var child_process = require('child_process');
 window.$ = require('jquery');
 var fs = require('fs');
+var path = require('path');
 var atomSpaceView = require('atom-space-pen-views');
 
 function wrappedFunScript() { 


### PR DESCRIPTION
This pull request addresses issue #34, adding `require('path')` as needed by ionide-paket on platforms using Mono.
